### PR TITLE
chore(mqtt): Avoid forced removal of all running Docker containers

### DIFF
--- a/mqtt/start.sh
+++ b/mqtt/start.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
 docker compose down
-docker rm -f $(docker ps -a -q)
-docker volume rm $(docker volume ls -q)
 docker compose up -d
 docker compose logs -f%


### PR DESCRIPTION
Start script may perform removal of all running and stopped Docker containers on the host. This includes sensitive containers such as Kind clusters and buildx containers. Do not remove those as part of the start script.