### PR TITLE
Precise application.properties as needed on the classpath for the ftp

### DIFF
--- a/ftp/application.properties
+++ b/ftp/application.properties
@@ -17,3 +17,5 @@ camel.beans.poolCF.connectionIdleTimeout = 20000
 
 # setup JMS component to use connection factory
 camel.component.jms.connection-factory = #bean:poolCF
+
+camel.jbang.classpathFiles=application.properties


### PR DESCRIPTION
example

otherwise it is using it only at build time when running with specifying only the file. The readme is specifying to run with * so picking it up automatically. It allows to have it working out of the box with the VS Code extensions.

Before:
[beforePR.webm](https://github.com/user-attachments/assets/54074c26-c4d9-4abe-b254-59dd2f7fc577)

After:
[afterPR.webm](https://github.com/user-attachments/assets/1c927cc7-2ea1-4be5-9cfd-e22db8a3c47a)
