### PR TITLE
Increase number of check for test on edit examples

### DIFF
--- a/edi-x12-as2/test/edi-x12-as2.camel.it.yaml
+++ b/edi-x12-as2/test/edi-x12-as2.camel.it.yaml
@@ -39,7 +39,7 @@ actions:
   - camel:
       jbang:
         verify:
-          maxAttempts: 3
+          maxAttempts: 20
           integration: "edi-x12-as2-camel"
           logMessage: ST*997*0001~
           delayBetweenAttempts: 5000


### PR DESCRIPTION
in case it is failing on CI because there is no cache and it takes too much time to start the route and download the dependencies