### PR TITLE
[CAMEL-21426] camel-jbang-examples

### DIFF
--- a/artemis/README.adoc
+++ b/artemis/README.adoc
@@ -1,0 +1,87 @@
+== Apache ActiveMQ Artemis
+
+This example shows how to setup connection factory to a remote Apache ActiveMQ Artemis
+messaging broker.
+
+=== Apache ActiveMQ Artemis
+
+You first need to have an ActiveMQ Artemis broker up and running.
+See more at: https://activemq.apache.org/components/artemis/
+
+You can run Artemis using
+
+[source,sh]
+----
+$ camel infra run artemis
+----
+
+Alternatively, you can run it with Docker manually
+
+[source,sh]
+----
+$ docker run --detach --name mycontainer -p 61616:61616 -p 8161:8161 --rm apache/activemq-artemis:latest-alpine
+----
+
+Either command will run the broker locally. To login you need to use `artemis` as username and password,
+in the `application.properties` file.
+
+
+=== Install JBang
+
+First install JBang according to https://www.jbang.dev
+
+When JBang is installed then you should be able to run from a shell:
+
+[source,sh]
+----
+$ jbang --version
+----
+
+This will output the version of JBang.
+
+To run this example you can either install Camel on JBang via:
+
+[source,sh]
+----
+$ jbang app install camel@apache/camel
+----
+
+Which allows to run Camel JBang with `camel` as shown below.
+
+=== How to run
+
+You can run this example using:
+
+[source,sh]
+----
+$ camel run *
+----
+
+Camel will start sending random numbers to Artemis and logging them. See `producer.camel.yaml` for route that sends the numbers
+and `consumer.camel.yaml` for route that logs them.
+
+=== Artemis configuration
+
+See the `application.properties` for how to configure to the ActiveMQ Artemis broker.
+
+=== Developer Web Console
+
+You can enable the developer console via `--console` flag as show:
+
+[source,sh]
+----
+$ camel run * --console
+----
+
+Then you can browse: http://localhost:8080/q/dev to introspect the running Camel Application.
+
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/artemis/application.properties
+++ b/artemis/application.properties
@@ -1,0 +1,19 @@
+# artemis connection factory
+camel.beans.artemisCF = #class:org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory
+# URL for broker
+camel.beans.artemisCF.brokerURL = tcp://localhost:61616
+
+# if broker requires specific login
+camel.beans.artemisCF.user = artemis
+camel.beans.artemisCF.password = artemis
+
+# pooled connection factory
+camel.beans.poolCF = #class:org.messaginghub.pooled.jms.JmsPoolConnectionFactory
+camel.beans.poolCF.connectionFactory = #bean:artemisCF
+camel.beans.poolCF.maxSessionsPerConnection = 500
+camel.beans.poolCF.connectionIdleTimeout = 20000
+# more options can be configured
+# https://github.com/messaginghub/pooled-jms/blob/main/pooled-jms-docs/Configuration.md
+
+# setup JMS component to use connection factory
+camel.component.jms.connection-factory = #bean:poolCF

--- a/artemis/consumer.camel.yaml
+++ b/artemis/consumer.camel.yaml
@@ -1,0 +1,4 @@
+- from:
+    uri: jms:numbers
+    steps:
+      - log: ${body}

--- a/artemis/producer.camel.yaml
+++ b/artemis/producer.camel.yaml
@@ -1,0 +1,8 @@
+- route:
+    from:
+      uri: timer:start
+      steps:
+        - setBody:
+            simple: ${random(100)}
+        - to:
+            uri: jms:numbers

--- a/circuit-breaker/README.adoc
+++ b/circuit-breaker/README.adoc
@@ -1,0 +1,61 @@
+== Circuit Breaker
+
+This example shows how Camel JBang can use circuit breaker EIP.
+
+=== Install JBang
+
+First install JBang according to https://www.jbang.dev
+
+When JBang is installed then you should be able to run from a shell:
+
+[source,sh]
+----
+$ jbang --version
+----
+
+This will output the version of JBang.
+
+To run this example you can either install Camel on JBang via:
+
+[source,sh]
+----
+$ jbang app install camel@apache/camel
+----
+
+Which allows to run Camel JBang with `camel` as shown below.
+
+=== How to run
+
+You can run this example using:
+
+[source,sh]
+----
+$ camel run *
+----
+
+While the Camel integration is running, then from another terminal type:
+
+[source,sh]
+----
+$ camel get circuit-breaker
+----
+
+Which then output the state of the circuit breaker. You can run this command with `--watch` and see
+how the state of the circuit breaker changes from closed to open due to many failures.
+
+[source,sh]
+----
+$ camel get circuit-breaker --watch
+----
+
+
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/circuit-breaker/route.camel.yaml
+++ b/circuit-breaker/route.camel.yaml
@@ -1,0 +1,26 @@
+- route:
+    from:
+      uri: timer:start
+      steps:
+        - setBody:
+            expression:
+              constant:
+                expression: Hello Camel
+        - circuitBreaker:
+            resilience4jConfiguration:
+              minimumNumberOfCalls: 10
+              failureRateThreshold: 50
+              waitDurationInOpenState: 20
+            steps:
+              - filter:
+                  expression:
+                    simple:
+                      expression: ${random(10)} > 2
+                  steps:
+                    - throwException:
+                        message: Forced error
+                        exceptionType: java.lang.IllegalArgumentException
+        - log:
+            message: "${body} (CircuitBreaker is open: ${exchangeProperty.CamelCircuitBreakerResponseShortCircuited})"
+      parameters:
+        period: 1000

--- a/routes/Greeter.java
+++ b/routes/Greeter.java
@@ -1,0 +1,20 @@
+package camel.example;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+public class Greeter implements Processor {
+
+    private String message;
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        String body = exchange.getIn().getBody(String.class);
+        exchange.getIn().setBody(message + " " + body);
+    }
+
+}

--- a/routes/README.adoc
+++ b/routes/README.adoc
@@ -1,0 +1,78 @@
+== Routes
+
+This example shows how routes are defined in Yaml.
+
+=== Install JBang
+
+First install JBang according to https://www.jbang.dev
+
+When JBang is installed then you should be able to run from a shell:
+
+[source,sh]
+----
+$ jbang --version
+----
+
+This will output the version of JBang.
+
+To run this example you can either install Camel on JBang via:
+
+[source,sh]
+----
+$ jbang app install camel@apache/camel
+----
+
+Which allows to run Camel JBang with `camel` as shown below.
+
+=== How to run
+
+You can run this example using:
+
+[source,sh]
+----
+$ camel run *
+----
+
+Camel will start a route that periodically provides a greeting message.
+
+=== Live reload
+
+You can run the example in dev mode which allows you to edit the example,
+and hot-reload when the file is saved.
+
+[source,sh]
+----
+$ camel run * --dev
+----
+
+=== Run directly from GitHub
+
+The example can also be run directly by referring to the GitHub URL as shown:
+
+[source,sh]
+----
+$ camel run https://github.com/apache/camel-jbang-examples/tree/main/routes
+----
+
+=== Developer Web Console
+
+You can enable the developer console via `--console` flag as show:
+
+[source,sh]
+----
+$ camel run * --console
+----
+
+Then you can browse: http://localhost:8080/q/dev to introspect the running Camel Application.
+Under "beans" Camel should display bean `greeter`.
+
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/routes/beans.yaml
+++ b/routes/beans.yaml
@@ -1,0 +1,5 @@
+- beans:
+  - name: "greeter"
+    type: "camel.example.Greeter"
+    properties:
+      message: 'Hello!'

--- a/routes/routes.camel.yaml
+++ b/routes/routes.camel.yaml
@@ -1,0 +1,12 @@
+- route:
+    id: greeting-route
+    from:
+      uri: timer:start
+      parameters:
+        period: 1000
+      steps:
+        - setBody:
+            simple: I'm ${routeId}
+        - bean:
+            ref: greeter
+        - log: ${body}

--- a/sql/README.adoc
+++ b/sql/README.adoc
@@ -1,0 +1,77 @@
+== SQL
+
+This example shows how to use a SQL database with Camel.
+
+The example comes with a `docker compose` file for running a local Postgres database.
+There is also a `application.properties` configuration file that setup
+a JDBC `DataSource` for connecting to the database.
+
+=== Install JBang
+
+First install JBang according to https://www.jbang.dev
+
+When JBang is installed then you should be able to run from a shell:
+
+[source,sh]
+----
+$ jbang --version
+----
+
+This will output the version of JBang.
+
+To run this example you can either install Camel on JBang via:
+
+[source,sh]
+----
+$ jbang app install camel@apache/camel
+----
+
+Which allows to run Camel JBang with `camel` as shown below.
+
+=== How to run
+
+You can run PostgreSQL using
+
+[source,sh]
+----
+$ camel infra run postgres
+----
+
+Alternatively, you can run it with Docker Compose:
+
+[source,sh]
+----
+$ docker compose up
+----
+
+or manually with just Docker
+
+[source,sh]
+----
+$ docker run \
+--env POSTGRES_DB=test \
+--env POSTGRES_USER=postgres \
+--env POSTGRES_PASSWORD=postgres \
+--publish 5432:5432 \
+postgres
+----
+
+After Docker starts and pulls down the Postgres image, you can run this example using:
+
+[source,sh]
+----
+$ camel run *
+----
+
+This runs several routes. The first one sets up a new table called _users_, the second one fills
+it with data and the third one runs a query on that table and logs the results.
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/sql/application.properties
+++ b/sql/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/test
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driverClassName=org.postgresql.Driver

--- a/sql/compose.yaml
+++ b/sql/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      - POSTGRES_DB=test
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'

--- a/sql/sql.camel.yaml
+++ b/sql/sql.camel.yaml
@@ -1,0 +1,20 @@
+- route:
+    from:
+      uri: timer:create?repeatCount=1&delay=500
+      steps:
+        - to:
+            uri: sql:CREATE TABLE IF NOT EXISTS users(id integer PRIMARY KEY, name varchar(20), byear integer);
+- route:
+    from:
+      uri: timer:insert?repeatCount=1&delay=1000
+      steps:
+        - to:
+            uri: sql:INSERT INTO users(id, name, byear) VALUES(1, 'Camel', 2025) ON CONFLICT DO NOTHING;
+- route:
+    from:
+      uri: timer:select?repeatCount=1&delay=2000
+      steps:
+        - to:
+            uri: sql:SELECT * FROM users
+        - log:
+            message: ${body}

--- a/xslt/README.adoc
+++ b/xslt/README.adoc
@@ -1,0 +1,66 @@
+== XSLT Transformation
+
+This example shows a basic XML transformation using XSLT style sheet.
+
+=== Install JBang
+
+First install JBang according to https://www.jbang.dev
+
+When JBang is installed then you should be able to run from a shell:
+
+[source,sh]
+----
+$ jbang --version
+----
+
+This will output the version of JBang.
+
+To run this example you can either install Camel on JBang via:
+
+[source,sh]
+----
+$ jbang app install camel@apache/camel
+----
+
+Which allows to run Camel JBang with `camel` as shown below.
+
+=== How to run
+
+Then you can run this example using:
+
+[source,sh]
+----
+$ camel run *
+----
+
+This reads the XML input file from _./input/account.xml_ and applies XSL transformation.
+
+=== Live updates of message transformation
+
+You can do live changes to the stylesheet and see the output in real-time with Camel JBang by running:
+
+[source,bash]
+----
+$ camel transform message --body=file:input/account.xml --component=xslt --template=file:stylesheet.xsl --pretty --watch
+----
+
+You can then edit the `stylesheet.xsl` file, and save the file, and watch the terminal for updated result.
+
+=== Run directly from GitHub
+
+The example can also be run directly by referring to the GitHub URL as shown:
+
+[source,sh]
+----
+$ camel run https://github.com/apache/camel-jbang-examples/tree/main/xslt
+----
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/community/support/[let us know].
+
+We also love contributors, so
+https://camel.apache.org/community/contributing/[get involved] :-)
+
+The Camel riders!

--- a/xslt/consumer.camel.yaml
+++ b/xslt/consumer.camel.yaml
@@ -1,0 +1,13 @@
+- route:
+    from:
+      uri: file://input
+      parameters:
+        fileName: account.xml
+        noop: true
+      steps:
+        - to:
+            uri: xslt
+            parameters:
+              resourceUri: stylesheet.xsl
+        - log:
+            message: Transformed data:\n ${prettyBody}

--- a/xslt/input/account.xml
+++ b/xslt/input/account.xml
@@ -1,0 +1,9 @@
+<hash>
+  <id type="integer">1369</id>
+  <uid>8c946e1a-fdc5-40d3-9098-44271bdfad65</uid>
+  <account-number>8673088731</account-number>
+  <iban>GB38EFUA27474531363797</iban>
+  <bank-name>ABN AMRO MEZZANINE (UK) LIMITED</bank-name>
+  <routing-number>053228004</routing-number>
+  <swift-bic>AACCGB21</swift-bic>
+</hash>

--- a/xslt/stylesheet.xsl
+++ b/xslt/stylesheet.xsl
@@ -1,0 +1,11 @@
+<?xml version = "1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:template match="/">
+    <bank>
+    	<name><xsl:value-of select="/hash/bank-name/text()"/></name>
+    	<bic><xsl:value-of select="/hash/swift-bic/text()"/></bic>
+    </bank>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-21426

Based on examples from https://github.com/apache/camel-kamelets-examples
- **artemis** changed route definitions from Yaml to XML
- **circuit-breaker**
- **routes** a new example created from **hello-yaml** and **app-routes** to show what users can do with routes in Yaml DSL
- **sql** fixed version since the one Kamelet examples stopped to work over time. I've replaced the SQL scripts with Camel routes to set up the database since it didn't work on my Docker. I believe this way it's more transparent to the user what happens here and should be also more robust.
- **xslt** fixed version of xslt-transform. The original didn't work because it read data from no-longer existing website. I've replaced it with reading from file. I've also removed the -transform from the name since XSTL already states for transformation.


Based on requirements in JIRA, all the examples will feature Yaml DSL.