### PR TITLE
Fix artemis example: enable ObjectMessage for non-String bodies

### DIFF
--- a/artemis/producer.camel.yaml
+++ b/artemis/producer.camel.yaml
@@ -3,6 +3,6 @@
       uri: timer:start
       steps:
         - setBody:
-            simple: ${random(100)}
+            simple: '{"orderId": ${random(1000)}, "item": "widget", "quantity": ${random(10)}}'
         - to:
             uri: jms:numbers


### PR DESCRIPTION
## Summary

Since Camel 4.18.1, the JMS component defaults `objectMessageEnabled` to `false` for security hardening. The artemis example's producer sends an `Integer` body via `${random(100)}`, which requires `ObjectMessage` serialization. Without this flag, the example fails with:

```
java.lang.IllegalStateException: JMS ObjectMessage is disabled by default for security reasons
(creating ObjectMessage). Set objectMessageEnabled=true on the JMS endpoint or component to enable it.
```

This adds `camel.component.jms.object-message-enabled = true` to `application.properties` to restore the expected behavior.