### PR TITLE
CAMEL-23595: Add hasCitrusTests metadata to example catalog

### DIFF
--- a/camel-jbang-example-catalog.json
+++ b/camel-jbang-example-catalog.json
@@ -11,6 +11,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -32,6 +33,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "application.properties",
@@ -54,6 +56,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "application.properties",
@@ -71,6 +74,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "route.camel.yaml"
@@ -89,6 +93,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "cron-log.camel.yaml"
@@ -107,6 +112,7 @@
         ],
         "bundled": false,
         "requiresDocker": true,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -128,6 +134,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -150,6 +157,7 @@
         ],
         "bundled": false,
         "requiresDocker": true,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "application.properties",
@@ -170,6 +178,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -189,6 +198,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -208,6 +218,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -226,6 +237,7 @@
         ],
         "bundled": false,
         "requiresDocker": true,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "application.properties",
@@ -248,6 +260,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -267,6 +280,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "application.properties",
@@ -287,6 +301,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "application.properties",
@@ -307,6 +322,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "rest-api.camel.yaml"
@@ -324,6 +340,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "Greeter.java",
             "README.adoc",
@@ -344,6 +361,7 @@
         ],
         "bundled": false,
         "requiresDocker": false,
+        "hasCitrusTests": true,
         "files": [
             "README.adoc",
             "analyzer/application-dev.properties",
@@ -390,6 +408,7 @@
         ],
         "bundled": false,
         "requiresDocker": true,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "application.properties",
@@ -409,6 +428,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "timer-log.camel.yaml"
@@ -426,6 +446,7 @@
         ],
         "bundled": true,
         "requiresDocker": false,
+        "hasCitrusTests": false,
         "files": [
             "README.adoc",
             "consumer.camel.yaml",

--- a/generate-catalog.sh
+++ b/generate-catalog.sh
@@ -86,6 +86,20 @@ for dirpath, dirnames, filenames in sorted(os.walk(repo_root)):
 
     requires_docker = "compose.yaml" in filenames or "docker-compose.yaml" in filenames
 
+    # detect Citrus integration tests (also in sub-directories without own metadata)
+    has_citrus_tests = False
+    for sub_dirpath2, sub_dirnames2, sub_filenames2 in os.walk(dirpath):
+        sub_dirnames2[:] = [
+            d for d in sub_dirnames2
+            if not d.startswith(".") and d not in {"target", "node_modules"}
+            and not os.path.exists(os.path.join(sub_dirpath2, d, "metadata.json"))
+        ]
+        if os.path.basename(sub_dirpath2) == "test":
+            if any(f.endswith(".citrus.it.yaml") or f.endswith(".citrus.it.xml")
+                   for f in sub_filenames2):
+                has_citrus_tests = True
+                break
+
     entry = {
         "name": name,
         "title": meta["title"],
@@ -94,6 +108,7 @@ for dirpath, dirnames, filenames in sorted(os.walk(repo_root)):
         "tags": meta.get("tags", []),
         "bundled": meta.get("bundled", False),
         "requiresDocker": requires_docker,
+        "hasCitrusTests": has_citrus_tests,
         "files": files,
     }
     catalog.append(entry)


### PR DESCRIPTION
## Summary
- Update `generate-catalog.sh` to detect Citrus integration tests in example `test/` directories
- Add `hasCitrusTests` boolean field to each catalog entry
- Recursively detects `*.citrus.it.yaml` and `*.citrus.it.xml` files in `test/` subdirectories (handles nested examples like `smart-log-analyzer/first-iteration`)
- 7 examples currently flagged with `hasCitrusTests: true`

## Test plan
- [x] Run `./generate-catalog.sh` and verify `hasCitrusTests` appears in generated JSON
- [x] Verify `mqtt`, `ftp`, `aws/aws-sqs`, `aws/aws-s3-event-based`, `openapi/client`, `openapi/server`, `smart-log-analyzer` are detected as having Citrus tests
- [x] Verify examples without tests have `hasCitrusTests: false`

_Claude Code on behalf of Claus Ibsen_