### PR TITLE
CAMEL-23655: Update GitHub topics for better discoverability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,9 +20,20 @@ github:
   homepage: https://camel.apache.org
   labels:
     - camel
-    - integration
+    - examples
+    - jbang
     - low-code
+    - integration
+    - integration-framework
+    - enterprise-integration-patterns
     - java
+    - yaml
+    - kafka
+    - rest-api
+    - data-transformation
+    - cloud-native
+    - microservices
+    - mcp
   enabled_merge_buttons:
     merge: false
     rebase: true


### PR DESCRIPTION
## Summary

- Expand GitHub topics from 4 to 15 (out of 20 max) to improve discoverability
- Add `examples`, `jbang` to identify this as a JBang examples repository
- Add `integration-framework`, `enterprise-integration-patterns`
- Add capabilities: `yaml`, `kafka`, `rest-api`, `data-transformation`
- Add `cloud-native`, `microservices`, `mcp`
- Keep `low-code`

Follows the same topic expansion done in apache/camel#23673.

## Test plan

- [ ] After merge, verify topics appear on https://github.com/apache/camel-jbang-examples

_Claude Code on behalf of Claus Ibsen_