### PR TITLE
Rebrand Camel JBang to Camel CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Apache Camel JBang Examples
+# Apache Camel CLI Examples
 
 [Apache Camel](http://camel.apache.org/) is a powerful open source integration framework based on known
 Enterprise Integration Patterns with powerful bean integration.
 
 ## Introduction
 
-This project provides examples for low-code integrations with Apache Camel JBang.
+This project provides examples for low-code integrations with Apache Camel CLI.
 
 ### Examples
 
@@ -15,9 +15,9 @@ they can run without having to use traditional Java compilation or build systems
 
 All examples can run local on your computer from a CLI terminal by executing a few commands.
 
-These examples uses JBang as the CLI which is a great tool that makes using Java much easier.
+The Camel CLI is powered by [JBang](https://www.jbang.dev/) which makes using Java much easier.
 
-## Install Camel JBang
+## Install Camel CLI
 
 First install JBang according to https://www.jbang.dev
 
@@ -57,7 +57,7 @@ Now you can start running commands for the Citrus JBang app with `citrus`:
 citrus --version
 ```
 
-Usually the Citrus tests are written in YAML files and named accordingly to the Camel JBang route source file.
+Usually the Citrus tests are written in YAML files and named accordingly to the Camel CLI route source file.
 
 For instance the Camel route `mqtt.camel.yaml` route provides a test named `mqtt.citrus.it.yaml`.
 You can run the test with Citrus JBang like this:
@@ -71,7 +71,7 @@ Of course the test also performs some validation steps to make sure that the Cam
 
 ## Other Examples
 
-You can also find a set of various Camel JBang examples at: https://github.com/apache/camel-kamelets-examples/tree/main/jbang
+You can also find a set of various Camel CLI examples at: https://github.com/apache/camel-kamelets-examples/tree/main/jbang
 
 ## Help and contributions
 

--- a/artemis/README.md
+++ b/artemis/README.md
@@ -42,7 +42,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ### How to run
 

--- a/aws/aws-s3-event-based/README.md
+++ b/aws/aws-s3-event-based/README.md
@@ -4,7 +4,7 @@ In this sample you'll use the AWS S3 CDC Source Kamelet.
 
 Through the usage of EventBridge and SQS Services you'll be able to consume events from specific bucket.
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see ../../install.adoc for installation instructions -->
 

--- a/aws/aws-sqs/README.md
+++ b/aws/aws-sqs/README.md
@@ -3,7 +3,7 @@
 In this sample you'll use the AWS SQS Sink Kamelet.
 The Camel integration exposes a Http service and for each incoming request the message body data is pushed to an AWS SQS queue.
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see ../../install.adoc for installation instructions -->
 

--- a/circuit-breaker/README.md
+++ b/circuit-breaker/README.md
@@ -1,6 +1,6 @@
 ## Circuit Breaker
 
-This example shows how Camel JBang can use circuit breaker EIP.
+This example shows how Camel CLI can use circuit breaker EIP.
 
 ### Install JBang
 
@@ -20,7 +20,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ### How to run
 

--- a/edi-x12-as2/README.md
+++ b/edi-x12-as2/README.md
@@ -6,7 +6,7 @@ This example is contributed from the [Smooks](https://www.smooks.org/) community
 
 The Camel application (i.e., `camel/edi-x12-as2.camel.yaml`) represents the supplier and the downstream systems are mocked with the help of Camel routes (i.e., `camel/fake.camel.yaml`). The example integrates a flavour of EDI called [X12](https://x12.org/) over [AS2](https://camel.apache.org/components/next/as2-component.html). From the Camel application, the [Smooks component](https://camel.apache.org/components/next/smooks-component.html) is leveraged to parse the EDI purchase order and generate the EDI acknowledgement. Smooks breaks down the EDI purchase order into fragments so that individual EDI segments can be transformed and routed accordingly.
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see ../install.adoc for installation instructions -->
 
@@ -18,7 +18,7 @@ The Camel application (i.e., `camel/edi-x12-as2.camel.yaml`) represents the supp
     cd camel && camel run *
     ```
 
-2. From another terminal window, send an X12 850 purchase order to the AS2 Camel endpoint, or better yet, dispatch the message from Camel JBang as shown next:
+2. From another terminal window, send an X12 850 purchase order to the AS2 Camel endpoint, or better yet, dispatch the message from Camel CLI as shown next:
 
     ```shell
     camel cmd send --body="$(cat test/payload.edi)" --endpoint="as2:client/send?inBody=ediMessage&targetHostName=localhost&targetPortNumber=8081&ediMessageContentType=application/edi-x12&ediMessageCharset=US-ASCII&as2From=acme&as2To=mycorp&from=alice@example.org&requestUri=/mycorp/orders&subject=Purchase Order&as2MessageStructure=PLAIN"

--- a/ftp/README.md
+++ b/ftp/README.md
@@ -4,7 +4,7 @@ This example shows how to integrate ActiveMQ with FTP server.
 
 ![](ftp-kaoto.png)
 
-## Install Camel JBang
+## Install Camel CLI
 
 include::../install.adoc[see installation]
 
@@ -44,7 +44,7 @@ camel run *
 
 When the example is running, you need to trigger Camel, by sending messages to the ActiveMQ broker.
 You can either do this via the broker web console http://localhost:8161 (login with `artemis/artemis`
-or by using Camel JBang (by sending the message into the existing running Camel named ftp):
+or by using Camel CLI (by sending the message into the existing running Camel named ftp):
 
 ```shell
 camel cmd send ftp --body=file:test/payload.xml
@@ -53,7 +53,7 @@ camel cmd send ftp --body=file:test/payload.xml
 ## Browsing FTP server
 
 When you have sent some messages to ActiveMQ Camel will route these to the FTP server.
-To see which files have been uploaded, you can start a remote shell into the Docker container or use Camel JBang:
+To see which files have been uploaded, you can start a remote shell into the Docker container or use Camel CLI:
 
 ```shell
 camel cmd browse

--- a/groovy/README.md
+++ b/groovy/README.md
@@ -1,6 +1,6 @@
 ## Groovy
 
-This example shows how to use Groovy with extra dependencies in Camel JBang.
+This example shows how to use Groovy with extra dependencies in Camel CLI.
 
 The route uses `EmailValidator` from [Apache Commons Validator](https://commons.apache.org/proper/commons-validator/)
 to validate an email address and route the message accordingly using content-based routing.
@@ -30,7 +30,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ### How to run
 

--- a/ibm/ibm-cos/README.md
+++ b/ibm/ibm-cos/README.md
@@ -24,11 +24,11 @@ You must have:
 
 ## Setup Kafka (for Kafka to IBM COS example)
 
-You need a running Kafka broker. The easiest way is to use Camel JBang's built-in infrastructure support.
+You need a running Kafka broker. The easiest way is to use Camel CLI's built-in infrastructure support.
 
 ### Start Kafka with JBang
 
-Start a local Kafka broker using Camel JBang:
+Start a local Kafka broker using Camel CLI:
 
 ```shell
 $ camel infra run kafka

--- a/ibm/ibm-watson-language/README.md
+++ b/ibm/ibm-watson-language/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to use IBM Watson Natural Language Understanding (
 * IBM Cloud account with Watson Natural Language Understanding service instance
 * IBM Cloud API key with access to Watson NLU
 
-## Install Camel JBang
+## Install Camel CLI
 
 include::../install.adoc[see installation]
 

--- a/keycloak-introspection-rest/README.md
+++ b/keycloak-introspection-rest/README.md
@@ -76,13 +76,13 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ## Running Keycloak
 
-### Option 1: Using Camel JBang Infra (Recommended)
+### Option 1: Using Camel CLI Infra (Recommended)
 
-Starting from Camel JBang 4.16.0, you can easily run Keycloak using the built-in infrastructure support:
+Starting from Camel CLI 4.16.0, you can easily run Keycloak using the built-in infrastructure support:
 
 ```sh
 $ jbang -Dcamel.jbang.version=4.16.0 camel@apache/camel infra run keycloak
@@ -124,7 +124,7 @@ After Keycloak starts, you need to configure it:
 ### 1. Access Keycloak Admin Console
 
 Open your browser and navigate to:
-* If using Camel JBang infra: http://localhost:8080
+* If using Camel CLI infra: http://localhost:8080
 * If using Docker manually: http://localhost:8180
 
 Login with:
@@ -538,7 +538,7 @@ To stop the Camel application, press `Ctrl+C`.
 
 To stop Keycloak:
 
-If you used Camel JBang infra:
+If you used Camel CLI infra:
 ```sh
 $ jbang -Dcamel.jbang.version=4.16.0 camel@apache/camel infra stop keycloak
 ```

--- a/keycloak-ldap-migration/README.md
+++ b/keycloak-ldap-migration/README.md
@@ -19,7 +19,7 @@ It leverages the `camel-ldap` component to read users from LDAP and the `camel-k
 
 * JBang installed (https://www.jbang.dev)
 * Access to an LDAP server with users to migrate
-* Keycloak server (can be started with Camel JBang infra)
+* Keycloak server (can be started with Camel CLI infra)
 * Basic understanding of LDAP and Keycloak concepts
 
 ## Dependencies
@@ -47,7 +47,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ## Setting Up LDAP Server
 
@@ -140,7 +140,7 @@ adding new entry "uid=admin,ou=users,dc=example,dc=org"
 
 ## Setting Up Keycloak
 
-Use Camel JBang Infra to run Keycloak:
+Use Camel CLI Infra to run Keycloak:
 
 ```sh
 $ camel infra run keycloak

--- a/keycloak-security-rest/README.md
+++ b/keycloak-security-rest/README.md
@@ -39,13 +39,13 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ## Running Keycloak
 
-### Option 1: Using Camel JBang Infra (Recommended)
+### Option 1: Using Camel CLI Infra (Recommended)
 
-Starting from Camel JBang 4.16.0, you can easily run Keycloak using the built-in infrastructure support:
+Starting from Camel CLI 4.16.0, you can easily run Keycloak using the built-in infrastructure support:
 
 ```sh
 $ jbang -Dcamel.jbang.version=4.16.0 camel@apache/camel infra run keycloak
@@ -87,7 +87,7 @@ After Keycloak starts, you need to configure it:
 ### 1. Access Keycloak Admin Console
 
 Open your browser and navigate to:
-* If using Camel JBang infra: http://localhost:8080
+* If using Camel CLI infra: http://localhost:8080
 * If using Docker manually: http://localhost:8180
 
 Login with:
@@ -320,7 +320,7 @@ To stop the Camel application, press `Ctrl+C`.
 
 To stop Keycloak:
 
-If you used Camel JBang infra:
+If you used Camel CLI infra:
 ```sh
 $ jbang -Dcamel.jbang.version=4.16.0 camel@apache/camel infra stop keycloak
 ```

--- a/mqtt/README.md
+++ b/mqtt/README.md
@@ -5,7 +5,7 @@ as illustrated below.
 
 ![](mqtt-kaoto.png)
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see installation instructions in ../install.adoc -->
 

--- a/openai/pii-redaction/README.md
+++ b/openai/pii-redaction/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to use OpenAI-compatible LLM providers with Apache
 * Java 17/21
 * A running LLM service with exposed OpenAI-compatible API (for chat completions)
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see installation instructions in ../install.adoc -->
 

--- a/openapi/client/README.md
+++ b/openapi/client/README.md
@@ -3,7 +3,7 @@
 This example uses the Open API specification as a base for a Camel REST client.
 The Camel route reads files from a local directory and sends the content in the form of an Open API REST request to a service.
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see installation instructions in ../../install.adoc -->
 

--- a/openapi/server/README.md
+++ b/openapi/server/README.md
@@ -3,7 +3,7 @@
 This example uses an Open API specification as a base for creating a REST service in Camel.
 The Camel route is configured to implement the operations declared in the Open API specification.
 
-## Install Camel JBang
+## Install Camel CLI
 
 <!-- see installation instructions in ../../install.adoc -->
 

--- a/pqc-document-signing/README.md
+++ b/pqc-document-signing/README.md
@@ -21,11 +21,11 @@ This example demonstrates how to build a secure document signing service using A
 
 ## Running HashiCorp Vault
 
-You can run HashiCorp Vault using either Camel JBang infrastructure support or Docker.
+You can run HashiCorp Vault using either Camel CLI infrastructure support or Docker.
 
-### Option 1: Using Camel JBang Infra (Recommended)
+### Option 1: Using Camel CLI Infra (Recommended)
 
-Use Camel JBang's built-in infrastructure support to easily run HashiCorp Vault:
+Use Camel CLI's built-in infrastructure support to easily run HashiCorp Vault:
 
 ```sh
 $ jbang -Dcamel.jbang.version=4.16.0 camel@apache/camel infra run hashicorp vault
@@ -307,7 +307,7 @@ To stop the Camel application, press `Ctrl+C`.
 
 To stop HashiCorp Vault:
 
-If using Camel JBang infra:
+If using Camel CLI infra:
 ```sh
 $ jbang -Dcamel.jbang.version=4.16.0 camel@apache/camel infra stop hashicorp-vault
 ```

--- a/routes/README.md
+++ b/routes/README.md
@@ -20,7 +20,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ### How to run
 

--- a/sql/README.md
+++ b/sql/README.md
@@ -24,7 +24,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ### How to run
 

--- a/xslt/README.md
+++ b/xslt/README.md
@@ -20,7 +20,7 @@ To run this example you can either install Camel on JBang via:
 $ jbang app install camel@apache/camel
 ```
 
-Which allows to run Camel JBang with `camel` as shown below.
+Which allows to run Camel CLI with `camel` as shown below.
 
 ### How to run
 
@@ -34,7 +34,7 @@ This reads the XML input file from _./input/account.xml_ and applies XSL transfo
 
 ### Live updates of message transformation
 
-You can do live changes to the stylesheet and see the output in real-time with Camel JBang by running:
+You can do live changes to the stylesheet and see the output in real-time with Camel CLI by running:
 
 ```bash
 $ camel transform message --body=file:input/account.xml --component=xslt --template=file:stylesheet.xsl --pretty --watch


### PR DESCRIPTION
## Summary

Rebrands all references from "Camel JBang" to "Camel CLI" across 21 README files.

JBang is still mentioned as the underlying technology (install instructions, commands), but the product branding is now consistently "Camel CLI" to align with how other frameworks name their CLI tools and improve AI discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)