### PR TITLE
CAMEL-23863: Fix invalid YAML in rest-api example

### DIFF
--- a/rest-api/rest-api.camel.yaml
+++ b/rest-api/rest-api.camel.yaml
@@ -1,10 +1,12 @@
 - rest:
     path: /api
-    steps:
-      - get:
-          path: /hello
-      - get:
-          path: "/hello/{name}"
+    get:
+      - path: /hello
+        to:
+          uri: direct:hello
+      - path: "/hello/{name}"
+        to:
+          uri: direct:hello-name
 - route:
     id: hello
     from:


### PR DESCRIPTION
## Motivation

The `rest-api` example's `rest-api.camel.yaml` nests the GET verbs under an unsupported `steps:` key:

```yaml
- rest:
    path: /api
    steps:
      - get:
          path: /hello
      - get:
          path: "/hello/{name}"
```

The Camel YAML DSL has no `steps:` child under `rest:`; verbs belong directly under `get:`/`post:`/etc. As a result the example fails at parse time (`UnsupportedFieldException`) and `camel run --example=rest-api` does not start.

## Fix

Use the proper `get:` verb list with explicit `to:` targets wiring each verb to its `direct` route, matching the canonical Camel YAML rest DSL structure:

```yaml
- rest:
    path: /api
    get:
      - path: /hello
        to:
          uri: direct:hello
      - path: "/hello/{name}"
        to:
          uri: direct:hello-name
```

The two `direct:hello` / `direct:hello-name` routes already present in the file remain unchanged.

## Related

This is the upstream source for the bundled example that is synced into `apache/camel` via the `sync-example-catalog` Maven profile. The same fix has been applied on the camel side, together with a new `ExampleRoutesLoadTest` that loads and parses every bundled example through the routes loader to prevent this class of regression:

- apache/camel#24340

Without this upstream change, the next example-catalog sync would re-introduce the broken file.

---
_Claude Code on behalf of Adriano Machado_