### PR TITLE
CAMEL-23864: fix edi-x12-as2 and openapi/server examples after YAML normalization

### DIFF
--- a/edi-x12-as2/camel/edi-x12-as2.camel.yaml
+++ b/edi-x12-as2/camel/edi-x12-as2.camel.yaml
@@ -1,5 +1,19 @@
 - routeConfiguration:
     id: as2Error
+    onException:
+      - onException:
+          exception:
+            - java.lang.Exception
+          handled:
+            constant:
+              expression: "true"
+          steps:
+            - script:
+                expression:
+                  groovy:
+                    expression: "httpContext = exchangeProperties['CamelAs2.interchange']\n\
+                      httpContext.setAttribute(org.apache.camel.component.as2.api.AS2Header.DISPOSITION_TYPE,\
+                      \ \n                         org.apache.camel.component.as2.api.entity.AS2DispositionType.FAILED)\n"
 - route:
     id: receivePurchaseOrder
     routeConfigurationId: as2Error
@@ -11,18 +25,6 @@
         requestUriPattern: /mycorp/orders
         serverPortNumber: 8081
       steps:
-        - onException:
-            exception:
-              - java.lang.Exception
-            handled:
-              constant:
-                expression: "true"
-        - script:
-            expression:
-              groovy:
-                expression: "httpContext = exchangeProperties['CamelAs2.interchange']\n\
-                  httpContext.setAttribute(org.apache.camel.component.as2.api.AS2Header.DISPOSITION_TYPE,\
-                  \ \n                         org.apache.camel.component.as2.api.entity.AS2DispositionType.FAILED)\n"
         - to:
             uri: jms
             parameters:
@@ -89,7 +91,7 @@
               as2From: mycorp
               as2MessageStructure: PLAIN
               as2To: acme
-              ediMessageCharset: charset=US-ASCII
+              ediMessageCharset: US-ASCII
               ediMessageContentType: application/edi-x12
               from: bob@example.org
               inBody: ediMessage

--- a/ftp/application.properties
+++ b/ftp/application.properties
@@ -19,3 +19,6 @@ camel.beans.poolCF.connectionIdleTimeout = 20000
 camel.component.jms.connection-factory = #bean:poolCF
 
 camel.jbang.classpathFiles=application.properties
+
+# Additional dependencies required at runtime (comma separated)
+camel.jbang.dependencies=jakarta.inject:jakarta.inject-api:2.0.1,jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0

--- a/ftp/jbang.properties
+++ b/ftp/jbang.properties
@@ -1,3 +1,2 @@
-# Declare required additional dependencies for testing
-run.deps=jakarta.inject:jakarta.inject-api:2.0.1,\
-jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0
+# Additional runtime dependencies are declared via camel.jbang.dependencies
+# in application.properties (Camel JBang natively supports comma separated lists).

--- a/openapi/server/petstore.camel.yaml
+++ b/openapi/server/petstore.camel.yaml
@@ -1,3 +1,6 @@
+- restConfiguration:
+    clientRequestValidation: true
+    apiContextPath: openapi
 - rest:
     openApi:
       specification: petstore-api.json


### PR DESCRIPTION
## Summary

Fixes two `camel-jbang-examples` integration tests that fail after the YAML canonical-form normalization in `60a70d8`. Verified locally against Camel 4.18.2 / Citrus 4.10.1; all 8 workflow suites now pass.

JIRA: [CAMEL-23864](https://issues.apache.org/jira/browse/CAMEL-23864) (related to [CAMEL-23863](https://issues.apache.org/jira/browse/CAMEL-23863))

## Changes

**`edi-x12-as2/camel/edi-x12-as2.camel.yaml`**
- Restored `onException` into the `as2Error` `routeConfiguration` (with the AS2 disposition-FAILED script handler). Normalization had moved it into the route `steps`, causing `Route receivePurchaseOrder has no output processors` at startup.
- Fixed `ediMessageCharset: charset=US-ASCII` → `US-ASCII` (invalid charset name, `IllegalCharsetNameException`). Latent since the example was added; only surfaced once the route started correctly.

**`openapi/server/petstore.camel.yaml`**
- Restored the `restConfiguration` block with `clientRequestValidation: true` and `apiContextPath: openapi`. It had been deleted, so the spec was no longer served at `/openapi` and the test received HTTP 404.

**`ftp` example (maintenance)**
- Moved runtime dependency declarations from `jbang.properties` (`run.deps`) to `camel.jbang.dependencies` in `application.properties` (natively supported comma-separated list).

## Testing

Ran the full `build.yml` workflow locally:

```
ftp/test                                PASS
mqtt/test                               PASS
openapi/server/test                     PASS
openapi/client/test                     PASS
aws/aws-s3-event-based/test             PASS
aws/aws-sqs/test                        PASS
edi-x12-as2/test                        PASS
smart-log-analyzer/first-iteration/test PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
